### PR TITLE
redis maxheap配置修改

### DIFF
--- a/src/main/java/geektime/im/lecture/redis/EmbededRedis.java
+++ b/src/main/java/geektime/im/lecture/redis/EmbededRedis.java
@@ -13,12 +13,14 @@ public class EmbededRedis {
 
     @Value("${spring.redis.port}")
     private int redisPort;
+    @Value("${spring.redis.maxheap}")
+    private String maxheap;
 
     private RedisServer redisServer;
 
     @PostConstruct
     public void startRedis() throws IOException {
-        redisServer = new RedisServer(redisPort);
+        redisServer = RedisServer.builder().setting("maxheap "+maxheap).port(redisPort).setting("bind localhost").build();
         redisServer.start();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,8 +21,9 @@ spring:
       ddl-auto: update
 
   redis:
-    host: localhost
+    host: 127.0.0.1
     port: 6379
+    maxheap: 200m
 
 websocket:
   connector:


### PR DESCRIPTION
项目在内存比较大的机器上redis无法启动；
我内存16g，项目启动会在C:\Users\admin\AppData\Local\Redis目录下创建差不多16g大小的文件RedisQFork打头的文件，应该是系统限制执行文件大小，导致redis一直无法启动