### PR TITLE
fix: 修复服务端关闭后，浏览器卡死，CPU占用率高问题

### DIFF
--- a/src/main/resources/static/js/ws_chat.js
+++ b/src/main/resources/static/js/ws_chat.js
@@ -66,25 +66,33 @@ var onmsg = function (event) {
 };
 
 function reconnect() {
-    websocket = new WebSocket("ws://127.0.0.1:8080");
-    $("#ws_status").text("重新上线");
-    websocket.onmessage = function (event) {
-        onmsg(event);
-    };
+    var isReconnect = false;
+    setTimeout(function () {
+        websocket = new WebSocket("ws://127.0.0.1:8080");
+        $("#ws_status").text("重新上线");
+        websocket.onmessage = function (event) {
+            onmsg(event);
+        };
 
-    websocket.onopen = function () {
-        bind();
-        heartBeat.start();
-    }
+        websocket.onopen = function () {
+            bind();
+            heartBeat.start();
+        }
 
-    websocket.onclose = function () {
-        reconnect();
-    };
+        websocket.onclose = function () {
+            if (!isReconnect) {
+                reconnect();
+                isReconnect = true;
+            }
+        };
 
-    websocket.onerror = function () {
-        reconnect();
-    };
-
+        websocket.onerror = function () {
+            if (!isReconnect) {
+                reconnect();
+                isReconnect = true;
+            }
+        };
+    }, 5000);
 }
 
 function sendMsg(event) {


### PR DESCRIPTION
`reconnect()` 方法每次调用都执行两次，导致调用次数指数级增长。